### PR TITLE
javadoc.xml: new: ant control fields for javadoc

### DIFF
--- a/javadoc.xml
+++ b/javadoc.xml
@@ -1,0 +1,22 @@
+<project name="jam-lib" default="javadoc" basedir=".">
+	<property name="src" location="src" />
+	<property name="doc" location="doc" />
+	<target name="init">
+		<!-- Create the doc folder -->
+		<mkdir dir="${doc}" />
+	</target>
+	<target name="javadoc" depends="init" description="generate the javadocs">
+		<javadoc
+			destdir="${doc}" 
+			author="true" 
+			version="true"
+			use="true"
+			windowtitle="JAM lib API"
+			access="public">
+			<packageset dir="${src}" />
+			<doctitle><![CDATA[<h1>JAM-lib</h1>]]></doctitle>
+			<bottom><![CDATA[<i>http://code.google.com/p/jam-lib/</i>]]></bottom>
+			<link href="http://java.sun.com/j2se/1.4.1/docs/api/"/>
+		</javadoc>
+	</target>
+</project>


### PR DESCRIPTION
This file was present for a long time in the Debian variant of the jam-lib source code, to allow for the production of the documentation package libjam-java-doc primarily.  Maybe this change would be of interest upstream.